### PR TITLE
Adding 2 examples in SpecPipe example documentation.

### DIFF
--- a/docs-website/docs/examples.md
+++ b/docs-website/docs/examples.md
@@ -16,3 +16,9 @@ sidebar_position: 3
 
 ### 4. Audio Data Mocking & Prometheus Exporter
 [This example](https://github.com/ml4wireless/specpipe/tree/main/_examples/mock_fm) streams the content of mock_audio.wav file (sampled at 32 KHz) to NATS JetStream circularly to simulate continuous audio collection. To monitor this data, this example further runs the Prometheus exporter.
+
+### 5. IQ Data Mocking and ADSB
+[This example](https://github.com/ml4wireless/specpipe/tree/main/_examples/iq_adsb) first streams the content of a file (exampledata.bin) containg IQ Data collected at the frequency of 1090 MHz, sampling rate of 2 MHz, and gain of 50 collected for 10 seconds to NATS Jetstream on a loop. Then it creates a client to fetch this IQ Data from Jetstream, processes it via Dump1090, decodes the output, and prints valid ADSB signal content to the console.
+
+### 6. Speech To Text Web Socket
+[This example](https://github.com/ml4wireless/specpipe/tree/main/_examples/speech-to-text-ws) is a simple FastAPI web server fetches FM data from NATS, decodes it into .wav chunks suitable for the SpeechRecognition model, and streams the text to any listeners via websocket


### PR DESCRIPTION
![image](https://github.com/ml4wireless/specpipe/assets/10257960/ecada512-ef17-4353-8c6d-153d7519efd8)
